### PR TITLE
Add Faraday dependency to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ gem install faraday-follow_redirects
 ## Usage
 
 ```ruby
+require 'faraday'
 require 'faraday/follow_redirects'
 
 Faraday.new(url: url) do |faraday|


### PR DESCRIPTION
I had a little trouble today getting the gem running in my code. When only requiring the `faraday/follow_redirects` in my code, I would get an error like this:

```
/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/faraday-follow_redirects-0.1.0/lib/faraday/follow_redirects/middleware.rb:23:in `<module:FollowRedirects>': uninitialized constant Faraday::Middleware (NameError)

    class Middleware < Faraday::Middleware
                              ^^^^^^^^^^^^
        from /Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/faraday-follow_redirects-0.1.0/lib/faraday/follow_redirects/middleware.rb:4:in `<module:Faraday>'
        from /Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/faraday-follow_redirects-0.1.0/lib/faraday/follow_redirects/middleware.rb:3:in `<top (required)>'
        from /Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/faraday-follow_redirects-0.1.0/lib/faraday/follow_redirects.rb:3:in `require_relative'
        from /Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/faraday-follow_redirects-0.1.0/lib/faraday/follow_redirects.rb:3:in `<top (required)>'
        from <internal:/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
        from <internal:/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
        from <internal:/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
        from example.rb:1:in `<main>'
<internal:/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- faraday/follow_redirects (LoadError)
        from <internal:/Users/tfruetel/.asdf/installs/ruby/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from example.rb:1:in `<main>'
```

After adding the Faraday dependency before the redirect gem, the error disappeared. I would suggest having the requirement for the Faraday gem itself in the example code to make it actually work.