### PR TITLE
gemspec: Fix URI to the repo

### DIFF
--- a/faraday-follow_redirects.gemspec
+++ b/faraday-follow_redirects.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.license = 'MIT'
 
-  github_uri = "https://github.com/tisba/#{spec.name}"
+  github_uri = "https://github.com/tisba/faraday-follow-redirects"
 
   spec.homepage = github_uri
 


### PR DESCRIPTION
The repo name does not follow the - and _ repo name conventions of other Faraday middlewares, but this would make it discoverable in RubyGems.org.