### PR TITLE
Update usage example with the shorthand alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ gem install faraday-follow_redirects
 require 'faraday/follow_redirects'
 
 Faraday.new(url: url) do |faraday|
-  faraday.use Faraday::FollowRedirects::Middleware
-
+  faraday.response :follow_redirects # use Faraday::FollowRedirects::Middleware
   faraday.adapter Faraday.default_adapter
 end
 ```

--- a/spec/integration/faraday/follow_redirects/middleware_spec.rb
+++ b/spec/integration/faraday/follow_redirects/middleware_spec.rb
@@ -80,4 +80,22 @@ RSpec.describe Faraday::FollowRedirects::Middleware do
     response = connection.get 'http://www.site-a.com'
     expect(response.env[:url].to_s).to eq('https://www.site-b.com/')
   end
+
+  describe 'usage via alias' do
+    it 'redirects on 301' do
+      stub_request(:get, 'http://www.site-a.com/').to_return(
+        status: 301,
+        headers: { 'Location' => 'https://www.site-b.com/' }
+      )
+      stub_request(:get, 'https://www.site-b.com/')
+
+      connection = Faraday.new do |conn|
+        conn.response :follow_redirects
+        conn.adapter Faraday.default_adapter
+      end
+
+      response = connection.get 'http://www.site-a.com'
+      expect(response.env[:url].to_s).to eq('https://www.site-b.com/')
+    end
+  end
 end


### PR DESCRIPTION
It looks like all other middlewares showcase examples with aliases. Is there a reason why this middleware doesn't?