### PR TITLE
allow "Location" header

### DIFF
--- a/lib/faraday/follow_redirects/middleware.rb
+++ b/lib/faraday/follow_redirects/middleware.rb
@@ -90,7 +90,7 @@ module Faraday
 
       def update_env(env, request_body, response)
         redirect_from_url = env[:url].to_s
-        redirect_to_url = safe_escape(response['location'] || '')
+        redirect_to_url = safe_escape(response['location'] || response['Location'] || '')
         env[:url] += redirect_to_url
 
         ENV_TO_CLEAR.each { |key| env.delete key }


### PR DESCRIPTION
While using this Gem, I encountered an issue where it inexplicably did not follow redirects properly.
After investigating the cause, I found that the web server uses the `"Location"` header.
According to [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2), it is written as `Location`, and I believe we should support this as well, so I created a pull request.