### PR TITLE
Support Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
           - "3.2" # EOL: 2026-03-31 (expected)
           - "3.3" # EOL: 2027-03-31 (expected)
           - "3.4"
+          - "4.0"
           # try Ruby head too
           - "head"
         gemfile:

--- a/faraday-follow_redirects.gemspec
+++ b/faraday-follow_redirects.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = ['>= 2.6', '< 4']
+  spec.required_ruby_version = ['>= 2.6']
 
   spec.add_dependency 'faraday', '>= 1', '< 3'
 end


### PR DESCRIPTION
The pull request proposes removing the < 4 upper bound on required_ruby_version in the gemspec. 
With Ruby 4.0 scheduled for release on Christmas Day and a preview already available.

Ruby 4.0.0 preview3 Released
https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/


the current constraint prevents gem install hoe from working on Ruby 4.0. Dropping the upper bound ensures the gem will install cleanly on Ruby 4.0 and future Ruby versions. 


